### PR TITLE
sharable logbook client and server handler

### DIFF
--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookClientHandler.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookClientHandler.java
@@ -1,6 +1,7 @@
 package org.zalando.logbook.netty;
 
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpContent;
@@ -24,6 +25,7 @@ import static org.zalando.logbook.netty.Conditionals.runIf;
 @API(status = EXPERIMENTAL)
 @NotThreadSafe
 @RequiredArgsConstructor
+@ChannelHandler.Sharable
 public final class LogbookClientHandler extends ChannelDuplexHandler {
 
     private final Sequence sequence = new Sequence(2);

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
@@ -1,6 +1,7 @@
 package org.zalando.logbook.netty;
 
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpContent;
@@ -24,6 +25,7 @@ import static org.zalando.logbook.netty.Conditionals.runIf;
 @API(status = EXPERIMENTAL)
 @NotThreadSafe
 @RequiredArgsConstructor
+@ChannelHandler.Sharable
 public final class LogbookServerHandler extends ChannelDuplexHandler {
 
     private final Sequence sequence = new Sequence(2);


### PR DESCRIPTION
Sharable Logbook Client and Server Handler between one or more channel pipeline.

## Description
- Annotated Logbook Client and Server Handler with @Sharable so same instance of the annotated handles can be added to one or more channel pipeline multiple times without a race condition.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Annotated Logbook Client and Server Handler with @Sharable so same instance of the annotated handler can be added to one or more channel pipeline multiple times without a race condition.

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
