### PR TITLE
Persistent Connection - Initialization of member variable moved at the method level.

### DIFF
--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookClientHandler.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookClientHandler.java
@@ -26,7 +26,7 @@ import static org.zalando.logbook.netty.Conditionals.runIf;
 @RequiredArgsConstructor
 public final class LogbookClientHandler extends ChannelDuplexHandler {
 
-    private final Sequence sequence = new Sequence(2);
+    private Sequence sequence;
 
     private final Logbook logbook;
 
@@ -40,6 +40,8 @@ public final class LogbookClientHandler extends ChannelDuplexHandler {
             final ChannelHandlerContext context,
             final Object message,
             final ChannelPromise promise) {
+
+        sequence = new Sequence(2);
 
         runIf(message, HttpRequest.class, httpRequest -> {
             this.request = new Request(context, LOCAL, httpRequest);

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
@@ -42,7 +42,6 @@ public final class LogbookServerHandler extends ChannelDuplexHandler {
 
         sequence = new Sequence(2);
 
-
         runIf(message, HttpRequest.class, httpRequest -> {
             this.request = new Request(context, REMOTE, httpRequest);
             this.requestStage = logbook.process(request);

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
@@ -26,7 +26,7 @@ import static org.zalando.logbook.netty.Conditionals.runIf;
 @RequiredArgsConstructor
 public final class LogbookServerHandler extends ChannelDuplexHandler {
 
-    private final Sequence sequence = new Sequence(2);
+    private Sequence sequence;
 
     private final Logbook logbook;
 
@@ -39,6 +39,9 @@ public final class LogbookServerHandler extends ChannelDuplexHandler {
     public void channelRead(
             final ChannelHandlerContext context,
             final Object message) {
+
+        sequence = new Sequence(2);
+
 
         runIf(message, HttpRequest.class, httpRequest -> {
             this.request = new Request(context, REMOTE, httpRequest);


### PR DESCRIPTION
Initialization of member variable `sequence` inside the first method of the call trace of LogbookClientHandler.java and LogbookServerHandler.java. 

## Description
Initialization of member variable `sequence` inside the first method of the call trace of LogbookClientHandler.java and LogbookServerHandler.java. This is to reset\initialize the state of the member variable for each request.

## Motivation and Context
https://github.com/zalando/logbook/issues/884

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
